### PR TITLE
change return types when planning & executing

### DIFF
--- a/arm_robots/src/arm_robots/base_robot.py
+++ b/arm_robots/src/arm_robots/base_robot.py
@@ -90,6 +90,7 @@ class DualArmRobot:
         self.right_gripper_command_pub.publish(self.get_close_gripper_msg())
 
     def get_close_gripper_msg(self):
+        # FIXME: this is a bad abstraction, not all grippers work like this
         raise NotImplementedError()
 
     def get_open_gripper_msg(self):


### PR DESCRIPTION
The old return type of `plan_*` was a mysterious tuple of tuples, which made error checking confusing. This should make things much clearer. This also returns more info from planning which previously was not done