### PR TITLE
Allow jacobian-based planning given a start state

### DIFF
--- a/jacobian_follower/CMakeLists.txt
+++ b/jacobian_follower/CMakeLists.txt
@@ -27,14 +27,15 @@ set(FLAGS -Wall -Wextra -Wpedantic -Wconversion -Wshadow -Werror=return-type -We
 
 add_library(jacobian_follower
         src/jacobian_follower/jacobian_utils.cpp
-        src/jacobian_follower/dual_gripper_shim.cpp
         src/jacobian_follower/jacobian_follower.cpp)
 target_include_directories(jacobian_follower PUBLIC include)
 target_include_directories(jacobian_follower SYSTEM PUBLIC ${catkin_INCLUDE_DIRS})
 target_link_libraries(jacobian_follower PUBLIC ${catkin_LIBRARIES})
 target_compile_options(jacobian_follower PUBLIC ${FLAGS})
 
-add_executable(jacobian_follower_main src/jacobian_follower/jacobian_follower_main.cpp)
+add_executable(jacobian_follower_main
+        src/jacobian_follower/jacobian_follower_main.cpp
+        src/jacobian_follower/dual_gripper_shim.cpp)
 target_link_libraries(jacobian_follower_main PUBLIC jacobian_follower)
 set_target_properties(jacobian_follower_main PROPERTIES OUTPUT_NAME "jacobian_follower")
 

--- a/jacobian_follower/src/jacobian_follower/bindings.cpp
+++ b/jacobian_follower/src/jacobian_follower/bindings.cpp
@@ -8,7 +8,6 @@
 
 namespace py = pybind11;
 
-
 PYBIND11_MODULE(pyjacobian_follower, m)
 {
   py::class_<JacobianFollower>(m, "JacobianFollower")
@@ -16,7 +15,27 @@ PYBIND11_MODULE(pyjacobian_follower, m)
            py::arg("robot_namespace"),
            py::arg("translation_step_size"),
            py::arg("minimize_rotation"))
-      .def("plan", &JacobianFollower::plan,
+      .def("plan_from_start_state", py::overload_cast<std::string const &,
+               std::vector<std::string> const &,
+               std::vector<Eigen::Vector4d> const &,
+               moveit_msgs::RobotState const &,
+               std::vector<std::vector<Eigen::Vector3d>> const &,
+               double,
+               double>(&JacobianFollower::plan_return_msg),
+           py::arg("group_name"),
+           py::arg("tool_names"),
+           py::arg("preferred_tool_orientations"),
+           py::arg("start_state"),
+           py::arg("grippers"),
+           py::arg("max_velocity_scaling_factor"),
+           py::arg("max_acceleration_scaling_factor")
+      )
+      .def("plan", py::overload_cast<std::string const &,
+               std::vector<std::string> const &,
+               std::vector<Eigen::Vector4d> const &,
+               std::vector<std::vector<Eigen::Vector3d>> const &,
+               double,
+               double>(&JacobianFollower::plan_return_msg),
            py::arg("group_name"),
            py::arg("tool_names"),
            py::arg("preferred_tool_orientations"),

--- a/jacobian_follower/src/jacobian_follower/dual_gripper_shim.cpp
+++ b/jacobian_follower/src/jacobian_follower/dual_gripper_shim.cpp
@@ -70,8 +70,14 @@ bool DualGripperShim::executeDualGripperTrajectory(arm_robots_msgs::GrippersTraj
     {
       target_point_sequence.emplace_back(gripper[waypoint_idx]);
     }
-    auto const traj = planner_->moveInWorldFrame(req.group_name, req.tool_names, preferred_orientations,
-                                                 target_point_sequence);
+    planning_scene_monitor::LockedPlanningSceneRW planning_scene(planner_->scene_monitor_);
+    auto const &start_state = planning_scene->getCurrentState();
+    auto const[traj, target_reached] = planner_->moveInWorldFrame(planning_scene,
+                                                                  req.group_name,
+                                                                  req.tool_names,
+                                                                  preferred_orientations,
+                                                                  start_state,
+                                                                  target_point_sequence);
     followJointTrajectory(traj);
   }
 


### PR DESCRIPTION
Adds a version of the jacobian-based `plan` method which (1) takes a start joint config and (2) returns whether the plan reaches the goal

Basically what's going on here:
 - create a new set of overloads for "plan", with all version eventually calling one particular version
 - carefully handle the RW lock of the planning scene
 - add a new python binding for a specific overload