### PR TITLE
fixes for small/empty jacobian motions

### DIFF
--- a/arm_robots/src/arm_robots/robot.py
+++ b/arm_robots/src/arm_robots/robot.py
@@ -31,6 +31,19 @@ store_error_msg = ("No stored tool orientations! "
                    "You have to call store_tool_orientations or store_current_tool_orientations first")
 
 
+def to_color_msg(color):
+    """
+
+    Args:
+        color: anything matplotlib can handle
+
+    Returns:
+
+    """
+    r, g, b, a = colors.to_rgba(color)
+    return ColorRGBA(r=r, g=g, b=b, a=a)
+
+
 class MoveitEnabledRobot(DualArmRobot):
 
     def __init__(self,

--- a/arm_robots/src/arm_robots/robot.py
+++ b/arm_robots/src/arm_robots/robot.py
@@ -31,19 +31,6 @@ store_error_msg = ("No stored tool orientations! "
                    "You have to call store_tool_orientations or store_current_tool_orientations first")
 
 
-def to_color_msg(color):
-    """
-
-    Args:
-        color: anything matplotlib can handle
-
-    Returns:
-
-    """
-    r, g, b, a = colors.to_rgba(color)
-    return ColorRGBA(r=r, g=g, b=b, a=a)
-
-
 class MoveitEnabledRobot(DualArmRobot):
 
     def __init__(self,

--- a/jacobian_follower/src/jacobian_follower/jacobian_follower.cpp
+++ b/jacobian_follower/src/jacobian_follower/jacobian_follower.cpp
@@ -189,7 +189,10 @@ PlanResult JacobianFollower::plan(planning_scene_monitor::LockedPlanningSceneRW 
     ROS_ERROR_STREAM_NAMED(LOGGER_NAME, "Time parametrization for the solution path failed.");
   }
 
-  visual_tools_.publishTrajectoryPath(robot_trajectory);
+  if (not robot_trajectory.empty())
+  {
+    visual_tools_.publishTrajectoryPath(robot_trajectory);
+  }
 
   return {robot_trajectory, reached_target};
 }
@@ -287,11 +290,6 @@ PlanResult JacobianFollower::moveInWorldFrame(planning_scene_monitor::LockedPlan
           max_dist = std::max(max_dist, dist);
         }
 
-  if (max_dist < translation_step_size_)
-  {
-    ROS_DEBUG_STREAM_NAMED(LOGGER_NAME, "Motion of distance " << max_dist << " requested. Ignoring");
-    return {robot_trajectory::RobotTrajectory{model_, group_name}, true};
-  }
   auto const steps = static_cast<std::size_t>(std::ceil(max_dist / translation_step_size_)) + 1;
   std::vector<PointSequence> tool_paths;
   BOOST_FOREACH(boost::tie(start_transform, target_position),


### PR DESCRIPTION
- publishing an empty trajectory gives a warning, so just don't do it
- I forget why we included the min step size check, so I'm removing it because it was causing annoying problems in my experiments