### PR TITLE
add more informative error message

### DIFF
--- a/arm_robots/src/arm_robots/robot.py
+++ b/arm_robots/src/arm_robots/robot.py
@@ -224,6 +224,9 @@ class MoveitEnabledRobot(DualArmRobot):
         rospy.logdebug(f"sending trajectory goal with f{len(trajectory.points)} points")
         result: Optional[FollowJointTrajectoryResult] = None
         if self.execute:
+            if client is None:
+                raise ValueError("You asked to execute an action without calling connect() first!")
+
             goal = self.make_follow_joint_trajectory_goal(trajectory)
 
             def _feedback_cb(feedback: FollowJointTrajectoryFeedback):

--- a/arm_robots/src/arm_robots/robot.py
+++ b/arm_robots/src/arm_robots/robot.py
@@ -225,7 +225,7 @@ class MoveitEnabledRobot(DualArmRobot):
         result: Optional[FollowJointTrajectoryResult] = None
         if self.execute:
             if client is None:
-                raise ValueError("You asked to execute an action without calling connect() first!")
+                raise ConnectionError("You asked to execute an action without calling connect() first!")
 
             goal = self.make_follow_joint_trajectory_goal(trajectory)
 


### PR DESCRIPTION
previously you'd get this mess:

```
Traceback (most recent call last):
  File "../link_bot_gazebo/scripts/restore_gazebo.py", line 39, in <module>
    main()
  File "/home/peter/catkin_ws_base/src/arc_utilities/src/arc_utilities/ros_init.py", line 65, in wrapper
    func(*args, **kwargs)
  File "../link_bot_gazebo/scripts/restore_gazebo.py", line 33, in main
    scenario.restore_from_bag(gazebo_service_provider, params, args.bagfile)
  File "/home/peter/catkin_ws/src/link_bot/link_bot_pycommon/src/link_bot_pycommon/dual_arm_sim_rope_scenario.py", line 188, in restore_from_bag
    self.robot.plan_to_joint_config("whole_body", joint_config)
  File "/home/peter/catkin_ws/src/arm_robots/arm_robots/src/arm_robots/robot.py", line 230, in plan_to_joint_config
    execution_result = self.follow_arms_joint_trajectory(planning_result.plan.joint_trajectory)
  File "/home/peter/catkin_ws/src/arm_robots/arm_robots/src/arm_robots/robot.py", line 281, in follow_arms_joint_trajectory
    return self.follow_joint_trajectory(trajectory, self.arms_client, stop_condition=stop_condition)
  File "/home/peter/catkin_ws/src/arm_robots/arm_robots/src/arm_robots/robot.py", line 261, in follow_joint_trajectory
    client.send_goal(goal, feedback_cb=_feedback_cb)
AttributeError: 'NoneType' object has no attribute 'send_goal'
```