### PR TITLE
change visualization of robot state

### DIFF
--- a/arm_robots/src/arm_robots/robot.py
+++ b/arm_robots/src/arm_robots/robot.py
@@ -394,7 +394,7 @@ class MoveitEnabledRobot(DualArmRobot):
         if display_robot_state_pub is None:
             display_robot_state_pub = rospy.Publisher(topic_name, DisplayRobotState, queue_size=10)
             try_to_connect(display_robot_state_pub)
-        self.display_robot_state_pubs[label] = display_robot_state_pub  # save a handle to the publisher
+            self.display_robot_state_pubs[label] = display_robot_state_pub  # save a handle to the publisher
 
         display_robot_state_msg = DisplayRobotState()
         display_robot_state_msg.state = robot_state
@@ -407,8 +407,7 @@ class MoveitEnabledRobot(DualArmRobot):
                 object_color = ObjectColor(id=link_name, color=color)
                 display_robot_state_msg.highlight_links.append(object_color)
 
-        if display_robot_state_pub is not None:
-            display_robot_state_pub.publish(display_robot_state_msg)
+        display_robot_state_pub.publish(display_robot_state_msg)
 
     def display_goal_position(self, point: Point):
         m = Marker()

--- a/arm_robots/src/arm_robots/robot.py
+++ b/arm_robots/src/arm_robots/robot.py
@@ -43,6 +43,7 @@ class MoveitEnabledRobot(DualArmRobot):
                  execute: bool = True,
                  block: bool = True,
                  raise_on_failure: bool = False,
+                 display_goals: bool = True,
                  force_trigger: float = 9.0):
         super().__init__(robot_namespace)
         self.max_velocity_scale_factor = 0.1
@@ -51,7 +52,7 @@ class MoveitEnabledRobot(DualArmRobot):
         self.execute = execute
         self.block = block
         self.force_trigger = force_trigger
-        self.display_goals = True
+        self.display_goals = display_goals
 
         self.arms_controller_name = arms_controller_name
 


### PR DESCRIPTION
publish_robot_state can now publish to different "labeled" robot state topics which is useful for showing different robot states with different meanings separately and simulatenously in rviz