### PR TITLE
Removed world static tf

### DIFF
--- a/arm_robots/launch/victor.launch
+++ b/arm_robots/launch/victor.launch
@@ -7,12 +7,6 @@
     <arg name="update_description" default="true"/>
     <arg name="verbose" default="false"/>
 
-    <group ns="static_transform_publishers">
-        <node pkg="tf2_ros" type="static_transform_publisher" name="rename_origin" required="true"
-              args="0 0 0 0 0 0 robot_root world">
-        </node>
-    </group>
-
     <group if="$(arg update_description)">
         <!-- uploads robot description and setups up other parameters -->
         <include file="$(find victor_moveit_config)/launch/planning_context.launch">


### PR DESCRIPTION
Currently there is a conflict in the tf_tree when running `victor.launch` and when running the `dual_arm_bridge`. I think the simplest correction is remove the static transform that sets "robot_root" the parent of "world". Conceptually, robot_root should be a child of world as well.

Some potential issues:
- We (I) have probably already written work-arounds for this odd TF tree, that'll need to be undone
- In simulation, we might be relying on this static publisher to create the linkage to the world frame. While I do not think the existing linkage is good, we might need to add in `world` some other way when running in simulation
 


`rosrun rqt_tf_tree` after running current `victor.launch`. See that `victor_root` is the parent^2 of `world`
![current_victor_launch](https://user-images.githubusercontent.com/7277089/118026332-b1ee8b00-b32e-11eb-8437-e6ec6cbe7b41.png)


tf tree after running `dual_arm_bridge.launch`: See that `world` is the parent of `victor root`
![current_dual_arm_bridge](https://user-images.githubusercontent.com/7277089/118027047-7d2f0380-b32f-11eb-9c2a-5eecb78a5bf1.png)


With these proposed changes:
![new_full_stack](https://user-images.githubusercontent.com/7277089/118027290-c3846280-b32f-11eb-9d8b-529862ed2279.png)

