### PR TITLE
add bindings to check if an instance of jacobian follower is collision checking

### DIFF
--- a/jacobian_follower/include/jacobian_follower/jacobian_follower.hpp
+++ b/jacobian_follower/include/jacobian_follower/jacobian_follower.hpp
@@ -205,6 +205,8 @@ class JacobianFollower {
 
   std::vector<std::string> getLinkNames() const;
 
+  bool isCollisionChecking() const;
+
   template <typename A, typename B>
   void validateNamesAndPositions(const std::vector<A> &joint_names, const std::vector<B> &joint_positions) const {
     if (joint_names.size() != joint_positions.size()) {

--- a/jacobian_follower/src/jacobian_follower/bindings.cpp
+++ b/jacobian_follower/src/jacobian_follower/bindings.cpp
@@ -61,6 +61,7 @@ PYBIND11_MODULE(pyjacobian_follower, m) {
                              std::vector<std::string> const &>(&JacobianFollower::getLinkToRobotTransforms, py::const_))
       .def("batch_get_link_to_robot_transforms", &JacobianFollower::batchGetLinkToRobotTransforms)
       .def("get_link_names", &JacobianFollower::getLinkNames)
+      .def("is_collision_checking", &JacobianFollower::isCollisionChecking)
       //
       ;
 }

--- a/jacobian_follower/src/jacobian_follower/jacobian_follower.cpp
+++ b/jacobian_follower/src/jacobian_follower/jacobian_follower.cpp
@@ -894,3 +894,5 @@ std::vector<std::vector<Eigen::Matrix4Xd>> JacobianFollower::batchGetLinkToRobot
   return transforms;
 }
 std::vector<std::string> JacobianFollower::getLinkNames() const { return model_->getLinkModelNames(); }
+
+bool JacobianFollower::isCollisionChecking() const { return static_cast<bool>(constraint_fun_); }


### PR DESCRIPTION
I like calling it isCollisionChecking because that's what it means now, even though what it actually does is check whether the more generic "constraint" function is being used