### PR TITLE
Unify cartesian impedance

### DIFF
--- a/arm_robots/src/arm_robots/base_robot.py
+++ b/arm_robots/src/arm_robots/base_robot.py
@@ -128,7 +128,7 @@ class BaseRobot:
                                                       lower, upper, world_frame_name, **kwargs)
 
     def move_delta_cartesian_impedance(self, arm, dx, dy, target_z=None, target_orientation=None,
-                                       step_size=0.005, blocking=True):
+                                       step_size=0.01, blocking=True):
         if self.cartesian is None:
             return False
 

--- a/arm_robots/src/arm_robots/base_robot.py
+++ b/arm_robots/src/arm_robots/base_robot.py
@@ -60,7 +60,7 @@ class BaseRobot:
         Get joint limits in radians with a safety margin
         """
         lower, upper = [], []
-        for joint_name in enumerate(joint_names):
+        for joint_name in joint_names:
             joint: moveit_commander.RobotCommander.Joint = self.robot_commander.get_joint(joint_name)
             lower.append(joint.min_bound() + safety_margin)
             upper.append(joint.max_bound() - safety_margin)
@@ -114,6 +114,7 @@ class BaseRobot:
     def create_cartesian_impedance_controller(self, motion_status_listeners: List[Listener],
                                               motion_command_publishers: List[rospy.Publisher],
                                               joint_names: List[str],
+                                              world_frame_name: str,
                                               **kwargs):
         """
         Create the cartesian impedance controller. The number of listeners should match the number of publishers and
@@ -124,7 +125,7 @@ class BaseRobot:
         self.cartesian = CartesianImpedanceController(self.tf_wrapper.tf_buffer,
                                                       motion_status_listeners,
                                                       motion_command_publishers,
-                                                      lower, upper, **kwargs)
+                                                      lower, upper, world_frame_name, **kwargs)
 
     def move_delta_cartesian_impedance(self, arm, dx, dy, target_z=None, target_orientation=None,
                                        step_size=0.005, blocking=True):

--- a/arm_robots/src/arm_robots/base_robot.py
+++ b/arm_robots/src/arm_robots/base_robot.py
@@ -30,6 +30,7 @@ class BaseRobot:
         try:
             self.robot_commander = moveit_commander.RobotCommander(ns=self.robot_namespace,
                                                                    robot_description=self.robot_description)
+
         except RuntimeError as e:
             rospy.logerr("You may need to load the moveit planning context and robot description")
             print(e)
@@ -51,6 +52,17 @@ class BaseRobot:
 
     def send_joint_command(self, joint_names: List[str], trajectory_point: JointTrajectoryPoint) -> Tuple[bool, str]:
         raise NotImplementedError()
+
+    def get_joint_limits(self, joint_names: List[str], safety_margin=1e-2):
+        """
+        Get joint limits in radians with a safety margin
+        """
+        lower, upper = [], []
+        for joint_name in enumerate(joint_names):
+            joint: moveit_commander.RobotCommander.Joint = self.robot_commander.get_joint(joint_name)
+            lower.append(joint.min_bound() + safety_margin)
+            upper.append(joint.max_bound() - safety_margin)
+        return lower, upper
 
     def get_joint_velocities(self, joint_names: Optional[List[str]] = None):
         """

--- a/arm_robots/src/arm_robots/cartesian.py
+++ b/arm_robots/src/arm_robots/cartesian.py
@@ -47,7 +47,7 @@ class CartesianImpedanceController:
         self.joint_lim_low = np.array(joint_lim_low)
         self.joint_lim_high = np.array(joint_lim_high)
         if np.any(self.joint_lim_low < -np.pi * 2) or np.any(self.joint_lim_high > np.pi * 2):
-            rospy.logwarn(f"Joint limits supplied may not be radians: {self.joint_lim_low} {self.joint_lim_high}")
+            rospy.logwarn(f"Joint limits supplied may be invalid radians: {self.joint_lim_low} {self.joint_lim_high}")
 
         # tf
         self.tf_buffer = tf_buffer

--- a/arm_robots/src/arm_robots/cartesian.py
+++ b/arm_robots/src/arm_robots/cartesian.py
@@ -83,6 +83,10 @@ class CartesianImpedanceController:
         self.motion_command_publisher = motion_command_publisher
 
     def set_active_arm(self, active_arm):
+        if self.target_pose is not None:
+            rospy.logwarn(f"Resetting active arm with an active target pose; aborting that target {self.target_pose}")
+            self.abort_goal()
+
         self.active_arm = active_arm
 
     def reset(self):

--- a/arm_robots/src/arm_robots/cartesian.py
+++ b/arm_robots/src/arm_robots/cartesian.py
@@ -23,6 +23,7 @@ def pose_distance(a: Pose, b: Pose, rot_weight=0):
 
 class CartesianImpedanceController:
     def __init__(self, tf_buffer, motion_status_listeners, motion_command_publisher, joint_lim_low, joint_lim_high,
+                 world_frame_name, sensor_frame_names=None,
                  position_close_enough=0.0025, timeout_per_m=500, intermediate_acceptance_factor=7.,
                  joint_limit_boundary=0.03):
         """
@@ -45,15 +46,18 @@ class CartesianImpedanceController:
         # joint limits, store as radians
         self.joint_lim_low = np.array(joint_lim_low)
         self.joint_lim_high = np.array(joint_lim_high)
-        if np.any(joint_lim_low < -np.pi * 2) or np.any(joint_lim_high > np.pi * 2):
+        if np.any(self.joint_lim_low < -np.pi * 2) or np.any(self.joint_lim_high > np.pi * 2):
             self.joint_lim_low *= np.pi / 180
             self.joint_lim_high *= np.pi / 180
 
         # tf
         self.tf_buffer = tf_buffer
         # what frames the measured cartesian pose is given in
-        self.sensor_frames = ["victor_left_arm_world_frame_kuka", "victor_right_arm_world_frame_kuka"]
-        self.world_frame = "victor_root"
+        self.world_frame = world_frame_name
+        if sensor_frame_names is None:
+            self.sensor_frames = [self.world_frame for _ in motion_status_listeners]
+        else:
+            self.sensor_frames = sensor_frame_names
 
         # goal parameters
         self._intermediate_target = None

--- a/arm_robots/src/arm_robots/cartesian.py
+++ b/arm_robots/src/arm_robots/cartesian.py
@@ -1,5 +1,4 @@
 import copy
-import enum
 
 import numpy as np
 import rospy
@@ -20,11 +19,6 @@ def pose_distance(a: Pose, b: Pose, rot_weight=0):
     pos_distance = np.linalg.norm(ros_numpy.numpify(a.position) - ros_numpy.numpify(b.position))
     rot_distance = 0 if rot_weight == 0 else rot_weight * quaternion_angle_diff(a.orientation, b.orientation)
     return pos_distance + rot_distance
-
-
-class ArmSide(enum.IntEnum):
-    LEFT = 0
-    RIGHT = 1
 
 
 class CartesianImpedanceController:
@@ -81,11 +75,11 @@ class CartesianImpedanceController:
         self._check_joint_limits = True
         self._start_violation = 0
 
-        self.active_arm = ArmSide.LEFT
+        self.active_arm = 0
         self.motion_status_listeners = motion_status_listeners
         self.motion_command_publisher = motion_command_publisher
 
-    def set_active_arm(self, active_arm: ArmSide):
+    def set_active_arm(self, active_arm):
         self.active_arm = active_arm
 
     def reset(self):

--- a/arm_robots/src/arm_robots/cartesian.py
+++ b/arm_robots/src/arm_robots/cartesian.py
@@ -31,8 +31,8 @@ class CartesianImpedanceController:
         :param tf_buffer: tf2 Buffer object
         :param motion_status_listeners: ROS listener (wrapper around subscriber) for status messages
         :param motion_command_publisher: ROS publisher for arm commands
-        :param joint_lim_low: lower joint limits in degrees or radians
-        :param joint_lim_high: upper joint limits in degrees or radians
+        :param joint_lim_low: lower joint limits in radians
+        :param joint_lim_high: upper joint limits in radians
         :param position_close_enough: Distance (m) to target position to be considered close enough
         :param timeout_per_m: Allowed time (s) to execute before timing out per 1m of travel
         :param joint_limit_boundary: Angle (radian or list of radian) boundary of each joint limit to avoid by
@@ -47,8 +47,7 @@ class CartesianImpedanceController:
         self.joint_lim_low = np.array(joint_lim_low)
         self.joint_lim_high = np.array(joint_lim_high)
         if np.any(self.joint_lim_low < -np.pi * 2) or np.any(self.joint_lim_high > np.pi * 2):
-            self.joint_lim_low *= np.pi / 180
-            self.joint_lim_high *= np.pi / 180
+            rospy.logwarn(f"Joint limits supplied may not be radians: {self.joint_lim_low} {self.joint_lim_high}")
 
         # tf
         self.tf_buffer = tf_buffer

--- a/arm_robots/src/arm_robots/med.py
+++ b/arm_robots/src/arm_robots/med.py
@@ -100,11 +100,8 @@ class BaseMed(BaseRobot):
         # are so why does it not enforce them?
 
         # TODO: use enforce bounds? https://github.com/ros-planning/moveit/pull/2356
-        limit_enforced_positions = []
-        for i, joint_name in enumerate(ARM_JOINT_NAMES):
-            joint: moveit_commander.RobotCommander.Joint = self.robot_commander.get_joint(joint_name)
-            limit_enforced_position = np.clip(positions[i], joint.min_bound() + 1e-2, joint.max_bound() - 1e-2)
-            limit_enforced_positions.append(limit_enforced_position)
+        low, high = self.get_joint_limits(ARM_JOINT_NAMES, safety_margin=1e-2)
+        limit_enforced_positions = np.clip(positions, low, high)
 
         # TODO: enforce velocity limits
         cmd = MotionCommand(joint_position=list_to_jvq(limit_enforced_positions),

--- a/arm_robots/src/arm_robots/med.py
+++ b/arm_robots/src/arm_robots/med.py
@@ -69,7 +69,8 @@ class BaseMed(BaseRobot):
         self.get_control_mode_srv = rospy.ServiceProxy(self.ns("get_control_mode_service"), GetControlMode)
         self.arm_status_listener = Listener(self.ns("motion_status"), MotionStatus)
         self.waypoint_state_pub = rospy.Publisher(self.ns("waypoint_robot_state"), DisplayRobotState, queue_size=10)
-        self.create_cartesian_impedance_controller([self.arm_status_listener], [self.arm_command_pub], ARM_JOINT_NAMES)
+        self.create_cartesian_impedance_controller([self.arm_status_listener], [self.arm_command_pub], ARM_JOINT_NAMES,
+                                                   "med_base")
 
     def send_joint_command(self, joint_names: Sequence[str], trajectory_point: JointTrajectoryPoint) -> Tuple[
         bool, str]:

--- a/arm_robots/src/arm_robots/med.py
+++ b/arm_robots/src/arm_robots/med.py
@@ -69,6 +69,7 @@ class BaseMed(BaseRobot):
         self.get_control_mode_srv = rospy.ServiceProxy(self.ns("get_control_mode_service"), GetControlMode)
         self.arm_status_listener = Listener(self.ns("motion_status"), MotionStatus)
         self.waypoint_state_pub = rospy.Publisher(self.ns("waypoint_robot_state"), DisplayRobotState, queue_size=10)
+        self.create_cartesian_impedance_controller([self.arm_status_listener], [self.arm_command_pub], ARM_JOINT_NAMES)
 
     def send_joint_command(self, joint_names: Sequence[str], trajectory_point: JointTrajectoryPoint) -> Tuple[
         bool, str]:

--- a/arm_robots/src/arm_robots/victor.py
+++ b/arm_robots/src/arm_robots/victor.py
@@ -30,7 +30,7 @@ from arm_robots.robot import MoveitEnabledRobot
 from arm_robots.robot_utils import make_joint_tolerance
 from victor_hardware_interface.victor_utils import get_control_mode_params, list_to_jvq, jvq_to_list, \
     default_gripper_command, gripper_status_to_list, is_gripper_closed
-from arm_robots.cartesian import CartesianImpedanceController, ArmSide
+from arm_robots.cartesian import CartesianImpedanceController
 
 
 def delegate_to_arms(positions: List, joint_names: Sequence[str]) -> Tuple[Dict[str, List], bool, str]:
@@ -260,7 +260,7 @@ class BaseVictor(BaseRobot):
             rospy.logerr(res.message)
         return res
 
-    def move_delta_cartesian_impedance(self, arm: ArmSide, dx, dy, target_z=None, target_orientation=None,
+    def move_delta_cartesian_impedance(self, arm, dx, dy, target_z=None, target_orientation=None,
                                        step_size=0.005, blocking=True):
         self.cartesian.set_active_arm(arm)
         if not self.cartesian.set_relative_goal_2d(dx, dy, target_z=target_z, target_orientation=target_orientation):

--- a/arm_robots/src/arm_robots/victor.py
+++ b/arm_robots/src/arm_robots/victor.py
@@ -107,7 +107,9 @@ class BaseVictor(BaseRobot):
         self.waypoint_state_pub = rospy.Publisher(self.ns("waypoint_robot_state"), DisplayRobotState, queue_size=10)
         self.create_cartesian_impedance_controller([self.left_arm_status_listener, self.right_arm_status_listener],
                                                    [self.left_arm_command_pub, self.right_arm_command_pub],
-                                                   RIGHT_ARM_JOINT_NAMES)
+                                                   RIGHT_ARM_JOINT_NAMES, "victor_root",
+                                                   sensor_frame_names=["victor_left_arm_world_frame_kuka",
+                                                                       "victor_right_arm_world_frame_kuka"])
 
     def send_joint_command(self, joint_names: Sequence[str], trajectory_point: JointTrajectoryPoint) -> Tuple[
         bool, str]:


### PR DESCRIPTION
This moves the cartesian impedance controller into the base robot to allow access by both Med and Victor. Also removes an ad-hoc way of defining joint limits.

Tested on Med.