### PR TITLE
remove world TF publisher, that's handled in the mocap TF launch files

### DIFF
--- a/arm_robots/launch/val.launch
+++ b/arm_robots/launch/val.launch
@@ -47,12 +47,6 @@
         </include>
     </group>
     <group unless="$(arg sim)">
-        <group ns="static_transform_publishers">
-            <node pkg="tf2_ros" type="static_transform_publisher" name="world_to_base_link" required="true"
-                  args="0 0 0 0 0 0 world base_link">
-            </node>
-        </group>
-
         <arg name="world_name" default="$(find arm_robots)/world/val_husky_walls.world"/>
 
         <!-- Start gazebo -->

--- a/arm_robots/world/val_husky_walls.world
+++ b/arm_robots/world/val_husky_walls.world
@@ -11,8 +11,8 @@
           <contact_max_correcting_vel>0</contact_max_correcting_vel>
         </constraints>
       </ode>
-      <max_step_size>0.001</max_step_size>
-      <real_time_update_rate>1000</real_time_update_rate>
+      <max_step_size>0.1</max_step_size>
+      <real_time_update_rate>10</real_time_update_rate>
     </physics>
 
     <plugin name="stepping_plugin" filename="libstepping_plugin.so"/>


### PR DESCRIPTION
also using 0.001 eats up CPU for no reason since the world has only static geometry and accurate physics is not needed